### PR TITLE
fix npm cache clean #1

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -21,7 +21,7 @@ COPY package.json package.json
 # This install npm dependencies on the resin.io build server,
 # making sure to clean up the artifacts it creates in order to reduce the image size.
 RUN JOBS=MAX npm install --production --unsafe-perm && \
-    npm cache clean && rm -rf /tmp/*
+    npm cache clean --force && rm -rf /tmp/*
 
 # This will copy all files in our root to the working directory in the container
 COPY . ./


### PR DESCRIPTION
`npm cache clean` throws with npm5

To delete the entire cache, run this command with --force.